### PR TITLE
Properly generate coverage data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ include(DefineProjectVersion)
 include(CurrentDate)
 include(PedanticCompilerWarnings)
 include(InstallFilesRecursive)
+include(EnableCoverageReport)
 
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_LIBS OFF)
@@ -123,6 +124,12 @@ if(BUILD_TESTS)
         message(WARNING "Could not build unit tests (as requested) because Google Mock could not be installed.")
     endif()
 endif()
+
+# coverage report
+
+enable_coverage_report(TARGETS ${RSBSPREAD_NAME}
+                       TESTS ${TEST_NAME}
+                       FILTER "*coverage/*" "*/test*")
 
 # pkgconfig file
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ make test       # opt. run unit tests
 make install    # install
 ```
 
-<!-- To generate a coverage report chose `coverage` as CMake build type and do -->
-<!--  -->
-<!-- ```sh -->
-<!-- make -->
-<!-- make test -->
-<!-- make coverage -->
-<!-- ``` -->
+To generate a coverage report chose `coverage` as CMake build type and do
+
+```sh
+make
+make test
+make coverage
+```
 
 # Contributing
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,7 @@ if(SPREAD_EXECUTABLE)
     add_test(${TEST_NAME}
              ${EXECUTABLE_OUTPUT_PATH}/${TEST_NAME}
              "--gtest_output=xml:${TEST_RESULT_DIR}/")
-             
+
     if(WIN32)
         set(PATH_STRING "$ENV{PATH};${Boost_LIBRARY_DIRS};${RSC_RUNTIME_LIBRARY_DIRS};${RSB_RUNTIME_LIBRARY_DIRS}")
         # requried for PATH entries with a slash before the semicolon
@@ -85,7 +85,7 @@ if(SPREAD_EXECUTABLE)
         set_property(TEST ${TEST_NAME}
                      PROPERTY ENVIRONMENT "PATH=${PATH_STRING}")
     endif()
-    
+
 endif()
 
 # Spread symlink workaround


### PR DESCRIPTION
Coverage data generation wasn't active in this project. The respective RSC macro has been added.